### PR TITLE
refactor(Application/ApplicationServiceRegistration): Add the BaseBusinessRules and AddSubClassesOfType method

### DIFF
--- a/src/corePackages/Core.Application/Rules/BaseBusinessRules.cs
+++ b/src/corePackages/Core.Application/Rules/BaseBusinessRules.cs
@@ -1,0 +1,6 @@
+﻿namespace Core.Application.Rules
+{
+    public abstract class BaseBusinessRules
+    {
+    }
+}

--- a/src/rentACar/Application/ApplicationServiceRegistration.cs
+++ b/src/rentACar/Application/ApplicationServiceRegistration.cs
@@ -32,6 +32,7 @@ using Core.Application.Pipelines.Authorization;
 using Core.Application.Pipelines.Caching;
 using Core.Application.Pipelines.Logging;
 using Core.Application.Pipelines.Validation;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Logging.Serilog;
 using Core.CrossCuttingConcerns.Logging.Serilog.Logger;
 using Core.ElasticSearch;
@@ -50,25 +51,7 @@ public static class ApplicationServiceRegistration
         services.AddAutoMapper(Assembly.GetExecutingAssembly());
         services.AddMediatR(Assembly.GetExecutingAssembly());
 
-        services.AddScoped<AdditionalServiceBusinessRules>();
-        services.AddScoped<AuthBusinessRules>();
-        services.AddScoped<BrandBusinessRules>();
-        services.AddScoped<CarBusinessRules>();
-        services.AddScoped<CarDamageBusinessRules>();
-        services.AddScoped<ColorBusinessRules>();
-        services.AddScoped<CorporateCustomerBusinessRules>();
-        services.AddScoped<CustomerBusinessRules>();
-        services.AddScoped<FindeksCreditRateBusinessRules>();
-        services.AddScoped<FuelBusinessRules>();
-        services.AddScoped<IndividualCustomerBusinessRules>();
-        services.AddScoped<InvoiceBusinessRules>();
-        services.AddScoped<ModelBusinessRules>();
-        services.AddScoped<RentalBusinessRules>();
-        services.AddScoped<RentalBranchBusinessRules>();
-        services.AddScoped<OperationClaimBusinessRules>();
-        services.AddScoped<UserBusinessRules>();
-        services.AddScoped<UserOperationClaimBusinessRules>();
-        services.AddScoped<TransmissionBusinessRules>();
+        services.AddSubClassesOfType(Assembly.GetExecutingAssembly(), typeof(BaseBusinessRules));
 
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehavior<,>));
@@ -93,6 +76,27 @@ public static class ApplicationServiceRegistration
         services.AddSingleton<LoggerServiceBase, FileLogger>();
         services.AddSingleton<IElasticSearch, ElasticSearchManager>();
 
+        return services;
+    }
+
+    public static IServiceCollection AddSubClassesOfType(
+        this IServiceCollection services,
+        Assembly assembly,
+        Type type,
+        Func<IServiceCollection, Type, IServiceCollection>? addWithLifeCycle = null)
+    {
+        var types = assembly.GetTypes().Where(t => t.IsSubclassOf(type) && type != t).ToList();
+        foreach (var item in types)
+        {
+            if (addWithLifeCycle == null)
+            {
+                services.AddScoped(item);
+            }
+            else
+            {
+                addWithLifeCycle(services, type);
+            }
+        }
         return services;
     }
 }

--- a/src/rentACar/Application/Features/AdditionalServices/Rules/AdditionalServiceBusinessRules.cs
+++ b/src/rentACar/Application/Features/AdditionalServices/Rules/AdditionalServiceBusinessRules.cs
@@ -1,12 +1,13 @@
 using Application.Features.AdditionalServices.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Persistence.Paging;
 using Domain.Entities;
 
 namespace Application.Features.AdditionalServices.Rules;
 
-public class AdditionalServiceBusinessRules
+public class AdditionalServiceBusinessRules : BaseBusinessRules
 {
     private readonly IAdditionalServiceRepository _additionalServiceRepository;
 

--- a/src/rentACar/Application/Features/Auths/Rules/AuthBusinessRules.cs
+++ b/src/rentACar/Application/Features/Auths/Rules/AuthBusinessRules.cs
@@ -1,5 +1,6 @@
 using Application.Features.Auths.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Security.Entities;
 using Core.Security.Enums;
@@ -7,7 +8,7 @@ using Core.Security.Hashing;
 
 namespace Application.Features.Auths.Rules;
 
-public class AuthBusinessRules
+public class AuthBusinessRules : BaseBusinessRules
 {
     private readonly IUserRepository _userRepository;
     private readonly IEmailAuthenticatorRepository _emailAuthenticatorRepository;

--- a/src/rentACar/Application/Features/Brands/Rules/BrandBusinessRules.cs
+++ b/src/rentACar/Application/Features/Brands/Rules/BrandBusinessRules.cs
@@ -1,12 +1,13 @@
 ﻿using Application.Features.Brands.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Persistence.Paging;
 using Domain.Entities;
 
 namespace Application.Features.Brands.Rules;
 
-public class BrandBusinessRules
+public class BrandBusinessRules : BaseBusinessRules
 {
     private readonly IBrandRepository _brandRepository;
 

--- a/src/rentACar/Application/Features/CarDamages/Rules/CarDamageBusinessRules.cs
+++ b/src/rentACar/Application/Features/CarDamages/Rules/CarDamageBusinessRules.cs
@@ -1,11 +1,12 @@
 using Application.Features.CarDamages.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Domain.Entities;
 
 namespace Application.Features.CarDamages.Rules;
 
-public class CarDamageBusinessRules
+public class CarDamageBusinessRules : BaseBusinessRules
 {
     private readonly ICarDamageRepository _carDamageRepository;
 

--- a/src/rentACar/Application/Features/Cars/Rules/CarBusinessRules.cs
+++ b/src/rentACar/Application/Features/Cars/Rules/CarBusinessRules.cs
@@ -1,12 +1,13 @@
 ﻿using Application.Features.Cars.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Domain.Entities;
 using Domain.Enums;
 
 namespace Application.Features.Cars.Rules;
 
-public class CarBusinessRules
+public class CarBusinessRules : BaseBusinessRules
 {
     private readonly ICarRepository _carRepository;
 

--- a/src/rentACar/Application/Features/Colors/Rules/ColorBusinessRules.cs
+++ b/src/rentACar/Application/Features/Colors/Rules/ColorBusinessRules.cs
@@ -1,12 +1,13 @@
 ﻿using Application.Features.Colors.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Persistence.Paging;
 using Domain.Entities;
 
 namespace Application.Features.Colors.Rules;
 
-public class ColorBusinessRules
+public class ColorBusinessRules : BaseBusinessRules
 {
     private readonly IColorRepository _colorRepository;
 

--- a/src/rentACar/Application/Features/CorporateCustomers/Rules/CorporateCustomerBusinessRules.cs
+++ b/src/rentACar/Application/Features/CorporateCustomers/Rules/CorporateCustomerBusinessRules.cs
@@ -1,12 +1,13 @@
 using Application.Features.CorporateCustomers.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Persistence.Paging;
 using Domain.Entities;
 
 namespace Application.Features.CorporateCustomers.Rules;
 
-public class CorporateCustomerBusinessRules
+public class CorporateCustomerBusinessRules : BaseBusinessRules
 {
     private readonly ICorporateCustomerRepository _corporateCustomerRepository;
 

--- a/src/rentACar/Application/Features/Customers/Rules/CustomerBusinessRules.cs
+++ b/src/rentACar/Application/Features/Customers/Rules/CustomerBusinessRules.cs
@@ -1,11 +1,12 @@
 using Application.Features.Customers.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Domain.Entities;
 
 namespace Application.Features.Customers.Rules;
 
-public class CustomerBusinessRules
+public class CustomerBusinessRules : BaseBusinessRules
 {
     private readonly ICustomerRepository _customerRepository;
 

--- a/src/rentACar/Application/Features/FindeksCreditRates/Rules/FindeksCreditRateBusinessRules.cs
+++ b/src/rentACar/Application/Features/FindeksCreditRates/Rules/FindeksCreditRateBusinessRules.cs
@@ -1,11 +1,12 @@
 using Application.Features.FindeksCreditRates.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Domain.Entities;
 
 namespace Application.Features.FindeksCreditRates.Rules;
 
-public class FindeksCreditRateBusinessRules
+public class FindeksCreditRateBusinessRules : BaseBusinessRules
 {
     private readonly IFindeksCreditRateRepository _findeksCreditRateRepository;
 

--- a/src/rentACar/Application/Features/Fuels/Rules/FuelBusinessRules.cs
+++ b/src/rentACar/Application/Features/Fuels/Rules/FuelBusinessRules.cs
@@ -1,12 +1,13 @@
 ﻿using Application.Features.Fuels.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Persistence.Paging;
 using Domain.Entities;
 
 namespace Application.Features.Fuels.Rules;
 
-public class FuelBusinessRules
+public class FuelBusinessRules : BaseBusinessRules
 {
     private readonly IFuelRepository _fuelRepository;
 

--- a/src/rentACar/Application/Features/IndividualCustomers/Rules/IndividualCustomerBusinessRules.cs
+++ b/src/rentACar/Application/Features/IndividualCustomers/Rules/IndividualCustomerBusinessRules.cs
@@ -1,12 +1,13 @@
 using Application.Features.IndividualCustomers.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Persistence.Paging;
 using Domain.Entities;
 
 namespace Application.Features.IndividualCustomers.Rules;
 
-public class IndividualCustomerBusinessRules
+public class IndividualCustomerBusinessRules : BaseBusinessRules
 {
     private readonly IIndividualCustomerRepository _individualCustomerRepository;
 

--- a/src/rentACar/Application/Features/Invoices/Rules/InvoiceBusinessRules.cs
+++ b/src/rentACar/Application/Features/Invoices/Rules/InvoiceBusinessRules.cs
@@ -1,11 +1,12 @@
 using Application.Features.Invoices.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Domain.Entities;
 
 namespace Application.Features.Invoices.Rules;
 
-public class InvoiceBusinessRules
+public class InvoiceBusinessRules : BaseBusinessRules
 {
     private readonly IInvoiceRepository _invoiceRepository;
 

--- a/src/rentACar/Application/Features/Models/Rules/ModelBusinessRules.cs
+++ b/src/rentACar/Application/Features/Models/Rules/ModelBusinessRules.cs
@@ -1,11 +1,12 @@
 ﻿using Application.Features.Models.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Domain.Entities;
 
 namespace Application.Features.Models.Rules;
 
-public class ModelBusinessRules
+public class ModelBusinessRules : BaseBusinessRules
 {
     private readonly IModelRepository _modelRepository;
 

--- a/src/rentACar/Application/Features/OperationClaims/Rules/OperationClaimBusinessRules.cs
+++ b/src/rentACar/Application/Features/OperationClaims/Rules/OperationClaimBusinessRules.cs
@@ -1,11 +1,12 @@
 using Application.Features.OperationClaims.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Security.Entities;
 
 namespace Application.Features.OperationClaims.Rules;
 
-public class OperationClaimBusinessRules
+public class OperationClaimBusinessRules : BaseBusinessRules
 {
     private readonly IOperationClaimRepository _operationClaimRepository;
 

--- a/src/rentACar/Application/Features/RentalBranches/Rules/RentalBranchBusinessRules.cs
+++ b/src/rentACar/Application/Features/RentalBranches/Rules/RentalBranchBusinessRules.cs
@@ -1,11 +1,12 @@
 using Application.Features.RentalBranches.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Domain.Entities;
 
 namespace Application.Features.RentalBranches.Rules;
 
-public class RentalBranchBusinessRules
+public class RentalBranchBusinessRules : BaseBusinessRules
 {
     private readonly IRentalBranchRepository _rentalBranchRepository;
 

--- a/src/rentACar/Application/Features/Rentals/Rules/RentalBusinessRules.cs
+++ b/src/rentACar/Application/Features/Rentals/Rules/RentalBusinessRules.cs
@@ -1,12 +1,13 @@
 ﻿using Application.Features.Rentals.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Persistence.Paging;
 using Domain.Entities;
 
 namespace Application.Features.Rentals.Rules;
 
-public class RentalBusinessRules
+public class RentalBusinessRules : BaseBusinessRules
 {
     private readonly IRentalRepository _rentalRepository;
 

--- a/src/rentACar/Application/Features/Transmissions/Rules/TransmissionBusinessRules.cs
+++ b/src/rentACar/Application/Features/Transmissions/Rules/TransmissionBusinessRules.cs
@@ -1,12 +1,13 @@
 ﻿using Application.Features.Transmissions.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Persistence.Paging;
 using Domain.Entities;
 
 namespace Application.Features.Transmissions.Rules;
 
-public class TransmissionBusinessRules
+public class TransmissionBusinessRules : BaseBusinessRules
 {
     private readonly ITransmissionRepository _transmissionRepository;
 

--- a/src/rentACar/Application/Features/UserOperationClaims/Rules/UserOperationClaimBusinessRules.cs
+++ b/src/rentACar/Application/Features/UserOperationClaims/Rules/UserOperationClaimBusinessRules.cs
@@ -1,11 +1,12 @@
 using Application.Features.UserOperationClaims.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Security.Entities;
 
 namespace Application.Features.UserOperationClaims.Rules;
 
-public class UserOperationClaimBusinessRules
+public class UserOperationClaimBusinessRules : BaseBusinessRules
 {
     private readonly IUserOperationClaimRepository _userOperationClaimRepository;
 

--- a/src/rentACar/Application/Features/Users/Rules/UserBusinessRules.cs
+++ b/src/rentACar/Application/Features/Users/Rules/UserBusinessRules.cs
@@ -1,12 +1,13 @@
 using Application.Features.Auths.Constants;
 using Application.Services.Repositories;
+using Core.Application.Rules;
 using Core.CrossCuttingConcerns.Exceptions;
 using Core.Security.Entities;
 using Core.Security.Hashing;
 
 namespace Application.Features.Users.Rules;
 
-public class UserBusinessRules
+public class UserBusinessRules : BaseBusinessRules
 {
     private readonly IUserRepository _userRepository;
 


### PR DESCRIPTION
Added the BaseBusinessRules to the core.Application.Rules and inherited all BusinessRule classes from it. Now we can register all BusinessRule classes by calling the new AddSubClassesOfType method.
Future feature: Since we will not have to add the BusinessRules to the registration, the BusinessRule classes can be separated now regarding the Commands and Queries, like CreateBrandBusinessRules, UpdateBrandBusinessRules etc.