### PR TITLE
fix(core.persistence): typos and violation of quality rules

### DIFF
--- a/src/corePackages/Core.Persistence/Paging/Paginate.cs
+++ b/src/corePackages/Core.Persistence/Paging/Paginate.cs
@@ -9,15 +9,15 @@ public class Paginate<T> : IPaginate<T>
         if (from > index)
             throw new ArgumentException($"indexFrom: {from} > pageIndex: {index}, must indexFrom <= pageIndex");
 
-        if (source is IQueryable<T> querable)
+        if (source is IQueryable<T> queryable)
         {
             Index = index;
             Size = size;
             From = from;
-            Count = querable.Count();
+            Count = queryable.Count();
             Pages = (int)Math.Ceiling(Count / (double)Size);
 
-            Items = querable.Skip((Index - From) * Size).Take(Size).ToList();
+            Items = queryable.Skip((Index - From) * Size).Take(Size).ToList();
         }
         else
         {

--- a/src/corePackages/Core.Persistence/Paging/Paginate.cs
+++ b/src/corePackages/Core.Persistence/Paging/Paginate.cs
@@ -34,7 +34,7 @@ public class Paginate<T> : IPaginate<T>
 
     public Paginate()
     {
-        Items = new T[0];
+        Items = Array.Empty<T>();
     }
 
     public int From { get; set; }


### PR DESCRIPTION
`
public Paginate()
    {
        Items = new T[0];
    }
`
Current code violates the CA1825 quality rule.
For more info: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1825