### PR TITLE
fix(persistence): switch expression failed error

### DIFF
--- a/src/rentACar/Persistence/Contexts/BaseDbContext.cs
+++ b/src/rentACar/Persistence/Contexts/BaseDbContext.cs
@@ -44,8 +44,9 @@ public class BaseDbContext : DbContext
     {
 
         IEnumerable<EntityEntry<Entity>> datas = ChangeTracker
-            .Entries<Entity>();
-        
+            .Entries<Entity>().Where(e =>
+                e.State == EntityState.Added || e.State == EntityState.Modified);
+
         foreach (var data in datas)
         {
             _ = data.State switch


### PR DESCRIPTION
Statuses other than Added and Modified give an 'Non-exhaustive switch expression failed to match its input.
Unmatched value was Unchanged.' error. This bug has been fixed.