### PR TITLE
feat(core): add transactionScope behavior for global rollback

### DIFF
--- a/src/corePackages/Core.Application/Pipelines/Transaction/TransactionScopeBehavior.cs
+++ b/src/corePackages/Core.Application/Pipelines/Transaction/TransactionScopeBehavior.cs
@@ -1,0 +1,29 @@
+﻿using MediatR;
+using System.Transactions;
+
+namespace Core.Application.Pipelines.Transaction
+{
+    public class TransactionScopeBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+    {
+        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        {
+            using (TransactionScope transactionScope = new(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                TResponse response;
+                try
+                {
+                    response = await next();
+                    transactionScope.Complete();
+                }
+                catch (Exception)
+                {
+                    transactionScope.Dispose();
+                    throw;
+                }
+
+                return response;
+            }
+        }
+    }
+}

--- a/src/rentACar/Application/ApplicationServiceRegistration.cs
+++ b/src/rentACar/Application/ApplicationServiceRegistration.cs
@@ -31,6 +31,7 @@ using Application.Services.UserService;
 using Core.Application.Pipelines.Authorization;
 using Core.Application.Pipelines.Caching;
 using Core.Application.Pipelines.Logging;
+using Core.Application.Pipelines.Transaction;
 using Core.Application.Pipelines.Validation;
 using Core.CrossCuttingConcerns.Logging.Serilog;
 using Core.CrossCuttingConcerns.Logging.Serilog.Logger;
@@ -76,6 +77,7 @@ public static class ApplicationServiceRegistration
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CacheRemovingBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestValidationBehavior<,>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TransactionScopeBehavior<,>));
 
 
         services.AddScoped<IAdditionalServiceService, AdditionalServiceManager>();


### PR DESCRIPTION
Although I have heard rumors that TransactionScope is not very compatible with Entity Framework Core 6, I did not observe a problem when I tested it. For this reason i wanted to add TransactionScopeBehavior to the project.