### PR TITLE
feat(core.persistence): bulk crud methods added and brand request int…

### DIFF
--- a/src/corePackages/Core.Persistence/Repositories/EfRepositoryBase.cs
+++ b/src/corePackages/Core.Persistence/Repositories/EfRepositoryBase.cs
@@ -67,6 +67,12 @@ public class EfRepositoryBase<TEntity, TContext> : IAsyncRepository<TEntity>, IR
         await Context.SaveChangesAsync();
         return entity;
     }
+    public async Task<List<TEntity>> AddRangeAsync(List<TEntity> entityList)
+    {
+        Context.AddRangeAsync(entityList);
+        await Context.SaveChangesAsync();
+        return entityList;
+    }
 
     public async Task<TEntity> UpdateAsync(TEntity entity)
     {
@@ -74,8 +80,20 @@ public class EfRepositoryBase<TEntity, TContext> : IAsyncRepository<TEntity>, IR
         await Context.SaveChangesAsync();
         return entity;
     }
+    public async Task<List<TEntity>> UpdateRangeAsync(List<TEntity> entityList)
+    {
+        Context.Entry(entityList).State = EntityState.Modified;
+        await Context.SaveChangesAsync();
+        return entityList;
+    }
 
     public async Task<TEntity> DeleteAsync(TEntity entity)
+    {
+        Context.Entry(entity).State = EntityState.Deleted;
+        await Context.SaveChangesAsync();
+        return entity;
+    }
+    public async Task<List<TEntity>> DeleteRangeAsync(List<TEntity> entity)
     {
         Context.Entry(entity).State = EntityState.Deleted;
         await Context.SaveChangesAsync();
@@ -122,10 +140,22 @@ public class EfRepositoryBase<TEntity, TContext> : IAsyncRepository<TEntity>, IR
         Context.SaveChanges();
         return entity;
     }
+    public List<TEntity> AddRange(List<TEntity> entity)
+    {
+        Context.AddRange(entity);
+        Context.SaveChanges();
+        return entity;
+    }
 
     public TEntity Update(TEntity entity)
     {
         Context.Entry(entity).State = EntityState.Modified;
+        Context.SaveChanges();
+        return entity;
+    }
+    public List<TEntity> UpdateRange(List<TEntity> entity)
+    {
+        Context.UpdateRange(entity);
         Context.SaveChanges();
         return entity;
     }
@@ -136,6 +166,12 @@ public class EfRepositoryBase<TEntity, TContext> : IAsyncRepository<TEntity>, IR
         Context.SaveChanges();
         return entity;
     }
+    public List<TEntity> DeleteRange(List<TEntity> entity)
+    {
+        Context.RemoveRange(entity);
+        Context.SaveChanges();
+        return entity;
+    }
 
-    
+
 }

--- a/src/corePackages/Core.Persistence/Repositories/IAsyncRepository.cs
+++ b/src/corePackages/Core.Persistence/Repositories/IAsyncRepository.cs
@@ -22,6 +22,9 @@ public interface IAsyncRepository<T> : IQuery<T> where T : Entity
                                              CancellationToken cancellationToken = default);
 
     Task<T> AddAsync(T entity);
+    Task<List<T>> AddRangeAsync(List<T> entity);
     Task<T> UpdateAsync(T entity);
+    Task<List<T>> UpdateRangeAsync(List<T> entity);
     Task<T> DeleteAsync(T entity);
+    Task<List<T>> DeleteRangeAsync(List<T> entity);
 }

--- a/src/corePackages/Core.Persistence/Repositories/IRepository.cs
+++ b/src/corePackages/Core.Persistence/Repositories/IRepository.cs
@@ -20,6 +20,9 @@ public interface IRepository<T> : IQuery<T> where T : Entity
                                   int index = 0, int size = 10, bool enableTracking = true);
 
     T Add(T entity);
+    List<T> AddRange(List<T> entity);
     T Update(T entity);
+    List<T> UpdateRange(List<T> entity);
     T Delete(T entity);
+    List<T> DeleteRange(List<T> entity);
 }

--- a/src/rentACar/Application/Features/Brands/Commands/CreateBrand/CreateBulkBrandCommand.cs
+++ b/src/rentACar/Application/Features/Brands/Commands/CreateBrand/CreateBulkBrandCommand.cs
@@ -1,0 +1,44 @@
+﻿using Application.Features.Brands.Dtos;
+using Application.Features.Brands.Rules;
+using Application.Services.Repositories;
+using AutoMapper;
+using Domain.Entities;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Features.Brands.Commands.CreateBrand
+{
+    public partial class CreateBulkBrandCommand : IRequest<List<CreatedBrandDto>>
+    {
+        public List<string> NameList { get; set; }
+
+        public class CreateBulkBrandCommandHandler : IRequestHandler<CreateBulkBrandCommand, List<CreatedBrandDto>>
+        {
+            private readonly IBrandRepository _brandRepository;
+            private readonly BrandBusinessRules _brandBusinessRules;
+
+            public CreateBulkBrandCommandHandler(IBrandRepository brandRepository,BrandBusinessRules brandBusinessRules)
+            {
+                _brandRepository = brandRepository;
+                _brandBusinessRules = brandBusinessRules;
+            }
+
+            public async Task<List<CreatedBrandDto>> Handle(CreateBulkBrandCommand request, CancellationToken cancellationToken)
+            {
+                if (request.NameList == null || request.NameList.Count == 0)
+                    await _brandBusinessRules.BrandNameListCanNotBeDuplicatedWhenInserted(request.NameList);                
+
+                List<Brand> mappedListBrand = request.NameList.Select(x => new Brand { Name = x, CreatedDate = DateTime.Now, UpdatedDate = DateTime.Now }).ToList();                            
+                List<Brand> createdListBrand = await _brandRepository.AddRangeAsync(mappedListBrand);                                            
+                List<CreatedBrandDto> result = createdListBrand.Select(x => new CreatedBrandDto { Id = x.Id, Name = x.Name }).ToList();                
+                return result;
+
+            }
+        }
+    }
+
+}

--- a/src/rentACar/Application/Features/Brands/Rules/BrandBusinessRules.cs
+++ b/src/rentACar/Application/Features/Brands/Rules/BrandBusinessRules.cs
@@ -27,4 +27,9 @@ public class BrandBusinessRules : BaseBusinessRules
         IPaginate<Brand> result = await _brandRepository.GetListAsync(b => b.Name == name);
         if (result.Items.Any()) throw new BusinessException(BrandMessages.BrandNameExists);
     }
+    public async Task BrandNameListCanNotBeDuplicatedWhenInserted(List<string> nameList)
+    {
+        IPaginate<Brand> result = await _brandRepository.GetListAsync(b => nameList.Contains(b.Name));
+        if (result.Items.Any()) throw new BusinessException(BrandMessages.BrandNameExists);
+    }
 }

--- a/src/rentACar/WebAPI/Controllers/BrandsController.cs
+++ b/src/rentACar/WebAPI/Controllers/BrandsController.cs
@@ -49,4 +49,12 @@ public class BrandsController : BaseController
         DeletedBrandDto result = await Mediator.Send(deleteBrandCommand);
         return Ok(result);
     }
+
+    [HttpPost("BulkInsert")]
+    public async Task<IActionResult> BulkInsert([FromBody] CreateBulkBrandCommand bulkBrandCommand)
+    {
+        List<CreatedBrandDto> result = await Mediator.Send(bulkBrandCommand);
+        return Created("", result);
+
+    }
 }


### PR DESCRIPTION
feat(core.persistence): bulk crud methods added and brand request integration

Bulk operations are very important for multiple data entry for a table, it is important in professional life. I realized that it was not in the project and I wanted to integrate it, the most appropriate table was a multi-brand entry request, I hope it was a useful feature for the community.