### PR TITLE
fix: entity UpdatedDate, exception logging and duplicated packages - codes

### DIFF
--- a/src/corePackages/Core.Application/Pipelines/Performance/PerformanceBehavior.cs
+++ b/src/corePackages/Core.Application/Pipelines/Performance/PerformanceBehavior.cs
@@ -26,7 +26,7 @@ public class PerformanceBehavior<TRequest, TResponse> : IPipelineBehavior<TReque
         try
         {
             _stopwatch.Start();
-            response = await next();            
+            response = await next();
         }
         finally
         {

--- a/src/corePackages/Core.CrossCuttingConcers/Exceptions/ExceptionMiddleware.cs
+++ b/src/corePackages/Core.CrossCuttingConcers/Exceptions/ExceptionMiddleware.cs
@@ -1,20 +1,15 @@
 ﻿using Core.CrossCuttingConcerns.Exceptions.Handlers;
-using Microsoft.AspNetCore.Http;
-
 using Core.CrossCuttingConcerns.Logging;
 using Core.CrossCuttingConcerns.Logging.Serilog;
-using FluentValidation;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
-using System.Net;
 
 namespace Core.CrossCuttingConcerns.Exceptions;
 
 public class ExceptionMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly HttpExceptionHandler _httpExceptionHandler = new();
+    private readonly HttpExceptionHandler _httpExceptionHandler;
     private readonly IHttpContextAccessor _contextAccessor;
     private readonly LoggerServiceBase _loggerService;
 
@@ -23,6 +18,7 @@ public class ExceptionMiddleware
         _next = next;
         _contextAccessor = contextAccessor;
         _loggerService = loggerService;
+        _httpExceptionHandler = new();
     }
 
     public async Task Invoke(HttpContext context)
@@ -46,13 +42,13 @@ public class ExceptionMiddleware
     }
 
     private Task LogException(HttpContext context, Exception exception)
-    { 
+    {
         List<LogParameter> logParameters = new()
         {
             new LogParameter
             {
                 Type = context.GetType().Name,
-                Value = context
+                Value = exception.ToString()
             }
         };
 

--- a/src/corePackages/Core.CrossCuttingConcers/Exceptions/Handlers/ExceptionHandler.cs
+++ b/src/corePackages/Core.CrossCuttingConcers/Exceptions/Handlers/ExceptionHandler.cs
@@ -18,7 +18,7 @@ namespace Core.CrossCuttingConcerns.Exceptions.Handlers
             else if (exception is NotFoundException notFoundException)
                 return HandleException(notFoundException);
 
-            else 
+            else
                 return HandleException(exception);
         }
 

--- a/src/corePackages/Core.CrossCuttingConcers/Exceptions/Handlers/ExceptionHandler.cs
+++ b/src/corePackages/Core.CrossCuttingConcers/Exceptions/Handlers/ExceptionHandler.cs
@@ -18,7 +18,8 @@ namespace Core.CrossCuttingConcerns.Exceptions.Handlers
             else if (exception is NotFoundException notFoundException)
                 return HandleException(notFoundException);
 
-            else return HandleException(exception);
+            else 
+                return HandleException(exception);
         }
 
         protected abstract Task HandleException(BusinessException businessException);

--- a/src/corePackages/Core.Persistence/Repositories/EfRepositoryBase.cs
+++ b/src/corePackages/Core.Persistence/Repositories/EfRepositoryBase.cs
@@ -1,8 +1,8 @@
-﻿using System.Linq.Expressions;
-using Core.Persistence.Dynamic;
+﻿using Core.Persistence.Dynamic;
 using Core.Persistence.Paging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
+using System.Linq.Expressions;
 
 namespace Core.Persistence.Repositories;
 

--- a/src/corePackages/Core.Persistence/Repositories/Entity.cs
+++ b/src/corePackages/Core.Persistence/Repositories/Entity.cs
@@ -4,7 +4,7 @@ public class Entity
 {
     public int Id { get; set; }
     public DateTime CreatedDate { get; set; }
-    public DateTime UpdatedDate { get; set; }
+    public DateTime? UpdatedDate { get; set; }
 
     public Entity()
     {

--- a/src/corePackages/Core.Persistence/Repositories/IAsyncRepository.cs
+++ b/src/corePackages/Core.Persistence/Repositories/IAsyncRepository.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq.Expressions;
-using Core.Persistence.Paging;
+﻿using Core.Persistence.Paging;
 using Microsoft.EntityFrameworkCore.Query;
+using System.Linq.Expressions;
 
 namespace Core.Persistence.Repositories;
 

--- a/src/corePackages/Core.Persistence/Repositories/IRepository.cs
+++ b/src/corePackages/Core.Persistence/Repositories/IRepository.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq.Expressions;
-using Core.Persistence.Paging;
+﻿using Core.Persistence.Paging;
 using Microsoft.EntityFrameworkCore.Query;
+using System.Linq.Expressions;
 
 namespace Core.Persistence.Repositories;
 

--- a/src/corePackages/Core.Security/JWT/JwtHelper.cs
+++ b/src/corePackages/Core.Security/JWT/JwtHelper.cs
@@ -1,11 +1,11 @@
-﻿using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Security.Cryptography;
-using Core.Security.Encryption;
+﻿using Core.Security.Encryption;
 using Core.Security.Entities;
 using Core.Security.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
 
 namespace Core.Security.JWT;
 

--- a/src/rentACar/Application/Features/Auths/Commands/RefleshToken/RefreshTokenCommand.cs
+++ b/src/rentACar/Application/Features/Auths/Commands/RefleshToken/RefreshTokenCommand.cs
@@ -48,7 +48,7 @@ public class RefreshTokenCommand : IRequest<RefreshedTokensDto>
             AccessToken createdAccessToken = await _authService.CreateAccessToken(user);
 
             RefreshedTokensDto refreshedTokensDto = new()
-                { AccessToken = createdAccessToken, RefreshToken = addedRefreshToken };
+            { AccessToken = createdAccessToken, RefreshToken = addedRefreshToken };
             return refreshedTokensDto;
         }
     }

--- a/src/rentACar/Application/Features/Auths/Commands/Register/RegisterCommand.cs
+++ b/src/rentACar/Application/Features/Auths/Commands/Register/RegisterCommand.cs
@@ -52,7 +52,7 @@ public class RegisterCommand : IRequest<RegisteredDto>
             RefreshToken addedRefreshToken = await _authService.AddRefreshToken(createdRefreshToken);
 
             RegisteredDto registeredDto = new()
-                { AccessToken = createdAccessToken, RefreshToken = addedRefreshToken };
+            { AccessToken = createdAccessToken, RefreshToken = addedRefreshToken };
             return registeredDto;
         }
     }

--- a/src/rentACar/Application/Features/Brands/Commands/CreateBrand/CreateBulkBrandCommand.cs
+++ b/src/rentACar/Application/Features/Brands/Commands/CreateBrand/CreateBulkBrandCommand.cs
@@ -1,14 +1,8 @@
 ﻿using Application.Features.Brands.Dtos;
 using Application.Features.Brands.Rules;
 using Application.Services.Repositories;
-using AutoMapper;
 using Domain.Entities;
 using MediatR;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Application.Features.Brands.Commands.CreateBrand
 {
@@ -21,7 +15,7 @@ namespace Application.Features.Brands.Commands.CreateBrand
             private readonly IBrandRepository _brandRepository;
             private readonly BrandBusinessRules _brandBusinessRules;
 
-            public CreateBulkBrandCommandHandler(IBrandRepository brandRepository,BrandBusinessRules brandBusinessRules)
+            public CreateBulkBrandCommandHandler(IBrandRepository brandRepository, BrandBusinessRules brandBusinessRules)
             {
                 _brandRepository = brandRepository;
                 _brandBusinessRules = brandBusinessRules;
@@ -30,11 +24,11 @@ namespace Application.Features.Brands.Commands.CreateBrand
             public async Task<List<CreatedBrandDto>> Handle(CreateBulkBrandCommand request, CancellationToken cancellationToken)
             {
                 if (request.NameList == null || request.NameList.Count == 0)
-                    await _brandBusinessRules.BrandNameListCanNotBeDuplicatedWhenInserted(request.NameList);                
+                    await _brandBusinessRules.BrandNameListCanNotBeDuplicatedWhenInserted(request.NameList);
 
-                List<Brand> mappedListBrand = request.NameList.Select(x => new Brand { Name = x, CreatedDate = DateTime.Now, UpdatedDate = DateTime.Now }).ToList();                            
-                List<Brand> createdListBrand = await _brandRepository.AddRangeAsync(mappedListBrand);                                            
-                List<CreatedBrandDto> result = createdListBrand.Select(x => new CreatedBrandDto { Id = x.Id, Name = x.Name }).ToList();                
+                List<Brand> mappedListBrand = request.NameList.Select(x => new Brand { Name = x, CreatedDate = DateTime.Now, UpdatedDate = DateTime.Now }).ToList();
+                List<Brand> createdListBrand = await _brandRepository.AddRangeAsync(mappedListBrand);
+                List<CreatedBrandDto> result = createdListBrand.Select(x => new CreatedBrandDto { Id = x.Id, Name = x.Name }).ToList();
                 return result;
 
             }

--- a/src/rentACar/Application/Features/CorporateCustomers/Commands/CreateCorporateCustomer/CreateCorporateCustomerCommand.cs
+++ b/src/rentACar/Application/Features/CorporateCustomers/Commands/CreateCorporateCustomer/CreateCorporateCustomerCommand.cs
@@ -49,7 +49,7 @@ public class CreateCorporateCustomerCommand : IRequest<CreatedCorporateCustomerD
                 await _corporateCustomerRepository.AddAsync(mappedCorporateCustomer);
 
             await _findeksCreditRateService.Add(new FindeksCreditRate
-                                                    { CustomerId = createdCorporateCustomer.CustomerId });
+            { CustomerId = createdCorporateCustomer.CustomerId });
 
             CreatedCorporateCustomerDto createdCorporateCustomerDto =
                 _mapper.Map<CreatedCorporateCustomerDto>(createdCorporateCustomer);

--- a/src/rentACar/Application/Features/IndividualCustomers/Commands/CreateIndividualCustomer/CreateIndividualCustomerCommand.cs
+++ b/src/rentACar/Application/Features/IndividualCustomers/Commands/CreateIndividualCustomer/CreateIndividualCustomerCommand.cs
@@ -51,7 +51,7 @@ public class CreateIndividualCustomerCommand : IRequest<CreatedIndividualCustome
                 await _individualCustomerRepository.AddAsync(mappedIndividualCustomer);
 
             await _findeksCreditRateService.Add(new FindeksCreditRate
-                                                    { CustomerId = createdIndividualCustomer.CustomerId });
+            { CustomerId = createdIndividualCustomer.CustomerId });
 
 
             CreatedIndividualCustomerDto createdIndividualCustomerDto =

--- a/src/rentACar/Application/Features/IndividualCustomers/Constants/IndividualCustomerMessages.cs
+++ b/src/rentACar/Application/Features/IndividualCustomers/Constants/IndividualCustomerMessages.cs
@@ -4,5 +4,5 @@ public static class IndividualCustomerMessages
 {
     public const string IndividualCustomerNotExists = "Individual customer not exists.";
     public const string IndividualCustomerNationalIdentityAlreadyExists = "Individual customer national identity already exists.";
-    
+
 }

--- a/src/rentACar/Application/Services/CarService/CarManager.cs
+++ b/src/rentACar/Application/Services/CarService/CarManager.cs
@@ -38,10 +38,10 @@ public class CarManager : ICarService
     public async Task<Car?> GetAvailableCarToRent(int modelId, int rentStartRentalBranch, DateTime rentStartDate,
                                                   DateTime rentEndDate)
     {
-        Car? carToFind = await _carRepository.GetAsync(c => c.ModelId == modelId && 
+        Car? carToFind = await _carRepository.GetAsync(c => c.ModelId == modelId &&
                                                             c.RentalBranchId == rentStartRentalBranch &&
-                                                            !c.Rentals.Any(r=>r.RentStartDate <= rentStartDate && r.RentEndDate >= rentEndDate), 
-                                                            include:i=>i.Include(i=>i.Rentals));
+                                                            !c.Rentals.Any(r => r.RentStartDate <= rentStartDate && r.RentEndDate >= rentEndDate),
+                                                            include: i => i.Include(i => i.Rentals));
         if (carToFind != null) return carToFind;
         throw new BusinessException("Available car doesn't exist.");
     }

--- a/src/rentACar/Application/Services/ImageService/ImageServiceBase.cs
+++ b/src/rentACar/Application/Services/ImageService/ImageServiceBase.cs
@@ -1,12 +1,5 @@
 ﻿using Core.CrossCuttingConcerns.Exceptions;
 using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using static Org.BouncyCastle.Bcpg.Attr.ImageAttrib;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Application.Services.ImageService;
 

--- a/src/rentACar/Domain/Entities/Rental.cs
+++ b/src/rentACar/Domain/Entities/Rental.cs
@@ -1,5 +1,4 @@
 ﻿using Core.Persistence.Repositories;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Domain.Entities;
 

--- a/src/rentACar/Domain/Entities/RentalBranch.cs
+++ b/src/rentACar/Domain/Entities/RentalBranch.cs
@@ -6,7 +6,7 @@ namespace Domain.Entities;
 public class RentalBranch : Entity
 {
     public City City { get; set; }
-   
+
 
     public virtual ICollection<Car> Cars { get; set; }
 

--- a/src/rentACar/Persistence/Contexts/BaseDbContext.cs
+++ b/src/rentACar/Persistence/Contexts/BaseDbContext.cs
@@ -38,30 +38,23 @@ public class BaseDbContext : DbContext
     {
         Configuration = configuration;
     }
-    
+
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = new CancellationToken())
     {
+        IEnumerable<EntityEntry<Entity>> entries = ChangeTracker
+            .Entries<Entity>()
+            .Where(e => e.State == EntityState.Added ||
+                        e.State == EntityState.Modified);
 
-        IEnumerable<EntityEntry<Entity>> datas = ChangeTracker
-            .Entries<Entity>().Where(e =>
-                e.State == EntityState.Added || e.State == EntityState.Modified);
-
-        foreach (var data in datas)
+        foreach (var entry in entries)
         {
-            _ = data.State switch
+            _ = entry.State switch
             {
-                EntityState.Added => data.Entity.CreatedDate = DateTime.UtcNow,
-                EntityState.Modified => data.Entity.UpdatedDate = DateTime.UtcNow
+                EntityState.Added => entry.Entity.CreatedDate = DateTime.UtcNow,
+                EntityState.Modified => entry.Entity.UpdatedDate = DateTime.UtcNow
             };
         }
         return await base.SaveChangesAsync(cancellationToken);
-    }
-    
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        //if (!optionsBuilder.IsConfigured)
-        //    base.OnConfiguring(
-        //        optionsBuilder.UseSqlServer(Configuration.GetConnectionString("RentACarConnectionString")));
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/rentACar/Persistence/EntityConfigurations/RentalConfiguration.cs
+++ b/src/rentACar/Persistence/EntityConfigurations/RentalConfiguration.cs
@@ -21,8 +21,8 @@ namespace Persistence.EntityConfigurations
             builder.Property(r => r.RentEndKilometer).HasColumnName("RentEndKilometer");
             builder.HasOne(r => r.Car);
             builder.HasOne(r => r.Customer);
-            builder.HasOne(r => r.RentStartRentalBranch).WithOne().HasForeignKey<Rental>(r=>r.RentStartRentalBranchId).OnDelete(DeleteBehavior.NoAction);
-            builder.HasOne(r => r.RentEndRentalBranch).WithOne().HasForeignKey<Rental>(r=>r.RentEndRentalBranchId).OnDelete(DeleteBehavior.NoAction);
+            builder.HasOne(r => r.RentStartRentalBranch).WithOne().HasForeignKey<Rental>(r => r.RentStartRentalBranchId).OnDelete(DeleteBehavior.NoAction);
+            builder.HasOne(r => r.RentEndRentalBranch).WithOne().HasForeignKey<Rental>(r => r.RentEndRentalBranchId).OnDelete(DeleteBehavior.NoAction);
             builder.HasMany(r => r.RentalsAdditionalServices);
         }
     }

--- a/src/rentACar/Persistence/Migrations/20221017160726_All.cs
+++ b/src/rentACar/Persistence/Migrations/20221017160726_All.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/rentACar/Persistence/Migrations/20221127171312_MakeUpdatedDateAsNullable.Designer.cs
+++ b/src/rentACar/Persistence/Migrations/20221127171312_MakeUpdatedDateAsNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Persistence.Contexts;
 
@@ -11,9 +12,10 @@ using Persistence.Contexts;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(BaseDbContext))]
-    partial class BaseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221127171312_MakeUpdatedDateAsNullable")]
+    partial class MakeUpdatedDateAsNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/rentACar/Persistence/Migrations/20221127171312_MakeUpdatedDateAsNullable.cs
+++ b/src/rentACar/Persistence/Migrations/20221127171312_MakeUpdatedDateAsNullable.cs
@@ -1,0 +1,669 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    public partial class MakeUpdatedDateAsNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Users",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "UserOperationClaims",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Transmissions",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "RentalsAdditionalServices",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Rentals",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "RentalBranches",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "RefreshTokens",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "OtpAuthenticators",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "OperationClaims",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Models",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Invoices",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedDate",
+                table: "Invoices",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(2022, 11, 27, 20, 13, 12, 150, DateTimeKind.Local).AddTicks(4631),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldDefaultValue: new DateTime(2022, 10, 17, 19, 7, 25, 692, DateTimeKind.Local).AddTicks(9094));
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "IndividualCustomers",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Fuels",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "FindeksCreditRates",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "EmailAuthenticators",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Customers",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "CorporateCustomers",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Colors",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Cars",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "CarDamages",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Brands",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "AdditionalServices",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.UpdateData(
+                table: "AdditionalServices",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "AdditionalServices",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Brands",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Brands",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Cars",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Cars",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Colors",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Colors",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Fuels",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Fuels",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Models",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Models",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "OperationClaims",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "Name", "UpdatedDate" },
+                values: new object[] { "admin", null });
+
+            migrationBuilder.UpdateData(
+                table: "RentalBranches",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "RentalBranches",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Transmissions",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Transmissions",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: null);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Users",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "UserOperationClaims",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Transmissions",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "RentalsAdditionalServices",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Rentals",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "RentalBranches",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "RefreshTokens",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "OtpAuthenticators",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "OperationClaims",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Models",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Invoices",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedDate",
+                table: "Invoices",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(2022, 10, 17, 19, 7, 25, 692, DateTimeKind.Local).AddTicks(9094),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldDefaultValue: new DateTime(2022, 11, 27, 20, 13, 12, 150, DateTimeKind.Local).AddTicks(4631));
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "IndividualCustomers",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Fuels",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "FindeksCreditRates",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "EmailAuthenticators",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Customers",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "CorporateCustomers",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Colors",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Cars",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "CarDamages",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "Brands",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "AdditionalServices",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "AdditionalServices",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "AdditionalServices",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Brands",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Brands",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Cars",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Cars",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Colors",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Colors",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Fuels",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Fuels",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Models",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Models",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "OperationClaims",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "Name", "UpdatedDate" },
+                values: new object[] { "Admin", new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                table: "RentalBranches",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "RentalBranches",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Transmissions",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "Transmissions",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UpdatedDate",
+                value: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/src/rentACar/Persistence/Persistence.csproj
+++ b/src/rentACar/Persistence/Persistence.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
   </ItemGroup>

--- a/src/rentACar/WebAPI/Controllers/AuthController.cs
+++ b/src/rentACar/WebAPI/Controllers/AuthController.cs
@@ -49,7 +49,7 @@ public class AuthController : BaseController
     public async Task<IActionResult> RefreshToken()
     {
         RefreshTokenCommand refreshTokenCommand = new()
-            { RefleshToken = getRefreshTokenFromCookies(), IPAddress = getIpAddress() };
+        { RefleshToken = getRefreshTokenFromCookies(), IPAddress = getIpAddress() };
         RefreshedTokensDto result = await Mediator.Send(refreshTokenCommand);
         setRefreshTokenToCookie(result.RefreshToken);
         return Created("", result.AccessToken);

--- a/src/rentACar/WebAPI/Controllers/CarsController.cs
+++ b/src/rentACar/WebAPI/Controllers/CarsController.cs
@@ -29,7 +29,7 @@ public class CarsController : BaseController
     public async Task<IActionResult> GetList([FromQuery] PageRequest pageRequest)
     {
         GetListCarQuery getListCarQuery = new()
-            { PageRequest = pageRequest };
+        { PageRequest = pageRequest };
         CarListModel result = await Mediator.Send(getListCarQuery);
         return Ok(result);
     }

--- a/src/rentACar/WebAPI/Controllers/FindeksCreditScoreController.cs
+++ b/src/rentACar/WebAPI/Controllers/FindeksCreditScoreController.cs
@@ -70,7 +70,8 @@ public class FindeksCreditRatesController : BaseController
         UpdateByUserIdFindeksCreditRateFromServiceCommand updateByUserIdFindeksCreditRateFromServiceCommand =
             new()
             {
-                UserId = getUserIdFromRequest(), IdentityNumber = updateByAuthFromServiceRequestDto.IdentityNumber
+                UserId = getUserIdFromRequest(),
+                IdentityNumber = updateByAuthFromServiceRequestDto.IdentityNumber
             };
 
         UpdatedFindeksCreditRateDto result = await Mediator.Send(updateByUserIdFindeksCreditRateFromServiceCommand);

--- a/src/rentACar/WebAPI/Program.cs
+++ b/src/rentACar/WebAPI/Program.cs
@@ -39,7 +39,6 @@ builder.Services.AddStackExchangeRedisCache(opt => opt.Configuration = "localhos
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 builder.Services.AddCors(opt => opt.AddDefaultPolicy(p => { p.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader(); }));
 builder.Services.AddSwaggerGen(opt =>
 {

--- a/src/rentACar/WebAPI/Properties/launchSettings.json
+++ b/src/rentACar/WebAPI/Properties/launchSettings.json
@@ -1,24 +1,14 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "iisSettings": {
-    "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:60805",
       "sslPort": 0
-    }
+    },
+    "windowsAuthentication": false
   },
   "profiles": {
-    "WebAPI": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5278",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
@@ -26,6 +16,16 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "WebAPI": {
+      "applicationUrl": "http://localhost:5278",
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "launchBrowser": true,
+      "launchUrl": "swagger"
     }
   }
 }

--- a/src/rentACar/WebAPI/appsettings.json
+++ b/src/rentACar/WebAPI/appsettings.json
@@ -1,39 +1,49 @@
 {
-  "WebAPIConfiguration": {
-    "APIDomain": "http://localhost:5278/api"
+  "AllowedHosts": "*",
+  "CacheSettings": {
+    "SlidingExpiration": 2
+  },
+  "CloudinaryAccount": {
+    "ApiKey": "",
+    "ApiSecret": "",
+    "Cloud": ""
   },
   "ConnectionStrings": {
     "RentACarConnectionString": "Server=(localdb)\\MSSQLLocalDB;Database=RentACarDb; Trusted_Connection=True;"
   },
+  "ElasticSearchConfig": {
+    "ConnectionString": "http://localhost:9200",
+    "Password": "",
+    "UserName": ""
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
   "MailSettings": {
-    "Server": "127.0.0.1",
-    "Port": 25,
-    "SenderFullName": "Ahmet Çetinkaya",
-    "SenderEmail": "ahmetcetinkaya7@outlook.com",
-    "UserName": "ahmetcetinkaya",
-    "Password": "12345678",
     "AuthenticationRequired": false,
     "DkimPrivateKey": "secret dkim key",
     "DkimSelector": "dkim selector",
-    "DomainName": "domain name"
-  },
-  "TokenOptions": {
-    "Audience": "rentacar@rentacar.com",
-    "Issuer": "rentacar@rentacar.com",
-    "AccessTokenExpiration": 10,
-    "SecurityKey": "strongandsecretkeystrongandsecretkey",
-    "RefreshTokenTTL": 2
+    "DomainName": "domain name",
+    "Password": "12345678",
+    "Port": 25,
+    "SenderEmail": "ahmetcetinkaya7@outlook.com",
+    "SenderFullName": "Ahmet Çetinkaya",
+    "Server": "127.0.0.1",
+    "UserName": "ahmetcetinkaya"
   },
   "SeriLogConfigurations": {
     "PostgreConfiguration": {
       "ConnectionString": "Host=localhost;Port=5432;Database=TestDb;Username=postgres;Password=test;",
-      "TableName": "Logs",
-      "NeedAutoCreateTable": true
+      "NeedAutoCreateTable": true,
+      "TableName": "Logs"
     },
     "MsSqlConfiguration": {
+      "AutoCreateSqlTable": true,
       "ConnectionString": "data source=NEPTUN\\DVLP2008;initial catalog=TestDb;persist security info=False;user id=sa;password=test^3;",
-      "TableName": "Logs",
-      "AutoCreateSqlTable": true
+      "TableName": "Logs"
     },
     "OracleConfiguration": {
       "ConnectionString": "Data Source=localhost:1521;User Id=SYSTEM;Password=test;"
@@ -45,8 +55,8 @@
       "ChannelHookAdress": ""
     },
     "MongoDbConfiguration": {
-      "ConnectionString": "mongodb://localhost:27017/customerdb?readPreference=primary&appname=MongoDB%20Compass&ssl=false",
-      "Collection": "logs"
+      "Collection": "logs",
+      "ConnectionString": "mongodb://localhost:27017/customerdb?readPreference=primary&appname=MongoDB%20Compass&ssl=false"
     },
     "ElasticSearchConfiguration": {
       "ConnectionString": "http://localhost:9200"
@@ -56,33 +66,23 @@
       "Port": 12201
     },
     "RabbitMQConfiguration": {
-      "Port": 5672,
       "Exchange": "test_exchange",
-      "Username": "guest",
-      "Password": "guest",
       "ExchangeType": "fanout",
+      "Hostnames": [ "localhost" ],
+      "Password": "guest",
+      "Port": 5672,
       "RouteKey": "Logs",
-      "Hostnames": ["localhost"]
+      "Username": "guest"
     }
   },
-  "CacheSettings": {
-    "SlidingExpiration": 2
+  "TokenOptions": {
+    "AccessTokenExpiration": 10,
+    "Audience": "rentacar@rentacar.com",
+    "Issuer": "rentacar@rentacar.com",
+    "RefreshTokenTTL": 2,
+    "SecurityKey": "strongandsecretkeystrongandsecretkey"
   },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "ElasticSearchConfig": {
-    "ConnectionString": "http://localhost:9200",
-    "UserName": "",
-    "Password": ""
-  },
-  "CloudinaryAccount": {
-    "Cloud": "",
-    "ApiKey": "",
-    "ApiSecret": ""
-  },
-  "AllowedHosts": "*"
+  "WebAPIConfiguration": {
+    "APIDomain": "http://localhost:5278/api"
+  }
 }

--- a/tests/Application.Tests/Startup.cs
+++ b/tests/Application.Tests/Startup.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Application.Tests
 {
-    public sealed class Startup 
+    public sealed class Startup
     {
         public void ConfigureServices(IServiceCollection services)
         {


### PR DESCRIPTION
- While logging the exception, the object enters an infinite loop and the operation fails.
- Made UpdateDate as nullable because UpdatedDate is required by the database when adding a new entity.
- Entity Framework 6 and Entity Framework Core conflict.
- General code cleanup.