### PR TITLE
refactor(application): behavior registration for mediatr version 12

### DIFF
--- a/src/rentACar/Application/ApplicationServiceRegistration.cs
+++ b/src/rentACar/Application/ApplicationServiceRegistration.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Application.Services.AdditionalServiceService;
+﻿using Application.Services.AdditionalServiceService;
 using Application.Services.AuthenticatorService;
 using Application.Services.AuthService;
 using Application.Services.CarService;
@@ -22,8 +21,8 @@ using Core.ElasticSearch;
 using Core.Mailing;
 using Core.Mailing.MailKitImplementations;
 using FluentValidation;
-using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
 
 namespace Application;
 
@@ -32,19 +31,20 @@ public static class ApplicationServiceRegistration
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
         services.AddAutoMapper(Assembly.GetExecutingAssembly());
-        services.AddMediatR(
-            configuration => configuration.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
+        services.AddMediatR(configuration =>
+        {
+            configuration.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+            configuration.AddOpenBehavior(typeof(AuthorizationBehavior<,>));
+            configuration.AddOpenBehavior(typeof(CachingBehavior<,>));
+            configuration.AddOpenBehavior(typeof(CacheRemovingBehavior<,>));
+            configuration.AddOpenBehavior(typeof(LoggingBehavior<,>));
+            configuration.AddOpenBehavior(typeof(RequestValidationBehavior<,>));
+            configuration.AddOpenBehavior(typeof(TransactionScopeBehavior<,>));
+        });
 
         services.AddSubClassesOfType(Assembly.GetExecutingAssembly(), typeof(BaseBusinessRules));
 
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehavior<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CachingBehavior<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CacheRemovingBehavior<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestValidationBehavior<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TransactionScopeBehavior<,>));
-
 
         services.AddScoped<IAdditionalServiceService, AdditionalServiceManager>();
         services.AddScoped<IAuthService, AuthManager>();


### PR DESCRIPTION
- Instead of the IServiceCollection.AddTransient method, use the new MediatRServiceConfiguration.AddOpenBehavior method, which is useful for recording generic behaviors.