### PR TITLE
refactor(CacheRemovingBehavior) - Bir sınıf/işlemde birden fazla alanın ön belleğini silme işlemi yapılması sağlandı.

### DIFF
--- a/src/rentACar/Application/Features/Brands/Commands/Create/CreateBrandCommand.cs
+++ b/src/rentACar/Application/Features/Brands/Commands/Create/CreateBrandCommand.cs
@@ -15,7 +15,7 @@ public class CreateBrandCommand : IRequest<CreatedBrandResponse>, ISecuredReques
 
     public bool BypassCache { get; }
     public string? CacheKey { get; }
-    public string CacheGroupKey => "GetBrands";
+    public string[] CacheGroupKey => new[] { CacheGroupKeyValue.BrandCacheGroupKey };
 
     public string[] Roles => new[] { Admin, Write, Add };
 

--- a/src/rentACar/Application/Features/Brands/Commands/Delete/DeleteBrandCommand.cs
+++ b/src/rentACar/Application/Features/Brands/Commands/Delete/DeleteBrandCommand.cs
@@ -16,7 +16,7 @@ public class DeleteBrandCommand : IRequest<DeletedBrandResponse>, ISecuredReques
 
     public bool BypassCache { get; }
     public string? CacheKey { get; }
-    public string CacheGroupKey => "GetBrands";
+    public string[] CacheGroupKey => new[] { CacheGroupKeyValue.BrandCacheGroupKey, CacheGroupKeyValue.ModelCacheGroupKey };
 
     public string[] Roles => new[] { Admin, Write, BrandsOperationClaims.Delete };
 

--- a/src/rentACar/Application/Features/Brands/Commands/Update/UpdateBrandCommand.cs
+++ b/src/rentACar/Application/Features/Brands/Commands/Update/UpdateBrandCommand.cs
@@ -17,7 +17,7 @@ public class UpdateBrandCommand : IRequest<UpdatedBrandResponse>, ISecuredReques
 
     public bool BypassCache { get; }
     public string? CacheKey { get; }
-    public string CacheGroupKey => "GetBrands";
+    public string[] CacheGroupKey => new[] { CacheGroupKeyValue.BrandCacheGroupKey, CacheGroupKeyValue.ModelCacheGroupKey };
 
     public string[] Roles => new[] { Admin, Write, BrandsOperationClaims.Update };
 

--- a/src/rentACar/Application/Features/CacheGroupKeyValue.cs
+++ b/src/rentACar/Application/Features/CacheGroupKeyValue.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Features;
+
+public static class CacheGroupKeyValue
+{
+    public const string BrandCacheGroupKey = "GetBrands";
+    public const string ModelCacheGroupKey = "GetModels";
+}

--- a/src/rentACar/Application/Features/Models/Commands/Create/CreateModelCommand.cs
+++ b/src/rentACar/Application/Features/Models/Commands/Create/CreateModelCommand.cs
@@ -20,7 +20,7 @@ public class CreateModelCommand : IRequest<CreatedModelResponse>, ISecuredReques
 
     public bool BypassCache { get; }
     public string? CacheKey { get; }
-    public string CacheGroupKey => "GetModels";
+    public string[] CacheGroupKey => new[] { CacheGroupKeyValue.ModelCacheGroupKey };
 
     public string[] Roles => new[] { Admin, Write, Add };
 

--- a/src/rentACar/Application/Features/Models/Commands/Delete/DeleteModelCommand.cs
+++ b/src/rentACar/Application/Features/Models/Commands/Delete/DeleteModelCommand.cs
@@ -15,7 +15,7 @@ public class DeleteModelCommand : IRequest<DeletedModelResponse>, ISecuredReques
 
     public bool BypassCache { get; }
     public string? CacheKey { get; }
-    public string CacheGroupKey => "GetModels";
+    public string[] CacheGroupKey => new[] { CacheGroupKeyValue.ModelCacheGroupKey };
 
     public string[] Roles => new[] { Admin, Write, ModelsOperationClaims.Delete };
 

--- a/src/rentACar/Application/Features/Models/Commands/Update/UpdateModelCommand.cs
+++ b/src/rentACar/Application/Features/Models/Commands/Update/UpdateModelCommand.cs
@@ -21,7 +21,7 @@ public class UpdateModelCommand : IRequest<UpdatedModelResponse>, ISecuredReques
 
     public bool BypassCache { get; }
     public string? CacheKey { get; }
-    public string CacheGroupKey => "GetModels";
+    public string[] CacheGroupKey => new[] { CacheGroupKeyValue.ModelCacheGroupKey };
 
     public string[] Roles => new[] { Admin, Write, ModelsOperationClaims.Update };
 


### PR DESCRIPTION
Örneğin: Model tablosuna eklenen bir Brand için güncelleme işlemi yaptığımızda model tablosunda ön bellek temizlenmediği için brand tablosunda değişiklik yapılan veri Model tablosunda değişmeme sorunu oluşuyordu. Bu sebepten dolayı cachGroupKey dizi türüne çevrildi.